### PR TITLE
Move Sidebar Toggle to Top

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,6 +10,11 @@
 </head>
 <body>
   <div id="app"></div>
+  <!-- Theme: Simple (latest v0.x.x) -->
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css"
+  />
   <script>
     window.$docsify = {
       name: '',


### PR DESCRIPTION
Move sidebar toggle to top for better mobile experience. Inspired by the docsify example - https://rest.sh/#/